### PR TITLE
Add to delimiterRegexp in utilities.js

### DIFF
--- a/chrome/content/zotero/xpcom/utilities.js
+++ b/chrome/content/zotero/xpcom/utilities.js
@@ -773,7 +773,7 @@ Zotero.Utilities = {
 			"down", "as"];
 		
 		// this may only match a single character
-		const delimiterRegexp = /([ \/\u002D\u00AD\u2010-\u2015\u2212\u2E3A\u2E3B])/;
+		const delimiterRegexp = /([ \/\u002D\u00AD\u2010-\u201F\u2212\u2E3A\u2E3B])/;
 		
 		string = this.trimInternal(string);
 		string = string.replace(/ : /g, ": ");


### PR DESCRIPTION
Added handful of characters including quotes that should be ignored when figuring out what starts a word for title case.
Per bug report at: https://forums.zotero.org/discussion/49510/title-casing-should-ignore-smart-quotes/
Reference: http://www.fileformat.info/info/unicode/char/search.htm?q=201&preview=entity
